### PR TITLE
Fixed issues with modify and import

### DIFF
--- a/source/ProSymbolEditor/Views/MilitarySymbolDockpane.xaml
+++ b/source/ProSymbolEditor/Views/MilitarySymbolDockpane.xaml
@@ -212,7 +212,7 @@
                                 </Grid.ColumnDefinitions>
 
                                 <Button Content="Add Favorite" Grid.Column="0" Style="{DynamicResource Esri_SimpleButton}" Command="{Binding SaveSymbolFileCommand}" HorizontalAlignment="Center" Width="90"/>
-                                <ToggleButton Name="searchAddToMapButton" Grid.Column="1" Content="Add to Map" IsEnabled="{Binding IsStyleItemSelected}" IsChecked="{Binding AddToMapToolEnabled, UpdateSourceTrigger=PropertyChanged}" Command="{Binding ActivateAddToMapToolCommand}" Height="24" Background="White" BorderBrush="Black" BorderThickness="0.5" ToolTip="Add to Map" HorizontalAlignment="Center" Width="90"/>
+                                <ToggleButton Name="searchAddToMapButton" Grid.Column="1" Content="Add to Map" IsEnabled="{Binding IsStyleItemSelected}" IsChecked="{Binding AddToMapToolEnabled, UpdateSourceTrigger=PropertyChanged}" Command="{Binding ActivateAddToMapToolCommand}" Height="24" Background="White" BorderBrush="Black" BorderThickness="0.5" ToolTip="Add to Map" HorizontalAlignment="Center" Width="90" Visibility="{Binding Path=IsAddingNew, Converter={StaticResource BoolToVis}}"/>
                                 <Button x:Name="modifyButton" Grid.Column="2" IsEnabled="{Binding IsStyleItemSelected}" Style="{DynamicResource Esri_BackButton}" Command="{Binding GoToTabCommand}" CommandParameter="3" ToolTip="Go to Modify Tab" HorizontalAlignment="Right" Margin="0,0,-26,0">
                                     <Button.RenderTransform>
                                         <ScaleTransform ScaleX="-1" />
@@ -518,7 +518,7 @@
 
                                 <Button Grid.Column="0" Grid.Row="0" Style="{DynamicResource Esri_BackButton}" Command="{Binding GoToTabCommand}" CommandParameter="0" HorizontalAlignment="Left" ToolTip="Back to Search"/>
                                 <Button Content="Add Favorite" Grid.Column="1" Grid.Row="0" Style="{DynamicResource Esri_SimpleButton}" Command="{Binding GoToTabCommand}" CommandParameter="1" HorizontalAlignment="Center" Width="81" Visibility="Collapsed"/>
-                                <ToggleButton Content="Add to Map" Grid.Column="2" Grid.Row="0" ToolTip="Add to Map" Command="{Binding ActivateAddToMapToolCommand}" IsChecked="{Binding AddToMapToolEnabled}" Height="24" Background="White" BorderBrush="Black" BorderThickness="0.5" HorizontalAlignment="Center" Width="82"/>
+                                <ToggleButton Content="Add to Map" Grid.Column="2" Grid.Row="0" ToolTip="Add to Map" Command="{Binding ActivateAddToMapToolCommand}" IsChecked="{Binding AddToMapToolEnabled}" Height="24" Background="White" BorderBrush="Black" BorderThickness="0.5" HorizontalAlignment="Center" Width="82" Visibility="{Binding Path=IsAddingNew, Converter={StaticResource BoolToVis}}"/>
                                 <Button Grid.Column="3" Grid.Row="0" Style="{DynamicResource Esri_BackButton}" Command="{Binding GoToTabCommand}" CommandParameter="3" ToolTip="New Symbol" HorizontalAlignment="Right" Margin="0,0,-26,0">
                                     <Button.RenderTransform>
                                         <ScaleTransform ScaleX="-1" />
@@ -991,7 +991,7 @@
                         </Grid>
 
                     </TabItem>
-                    <TabItem Header="Enter Coordinates" IsEnabled="{Binding IsStyleItemSelected}">
+                    <TabItem Header="Enter Coordinates" IsEnabled="{Binding IsCoordinateTabEnabled}">
                         <Grid>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="*"/>


### PR DESCRIPTION
Made the favorite import only import JSON files - it will filter everything else out.  If a user forces a selection of something else, it will throw an error message.

Updated the modify workflow so that when editing is enabled the coordinate tab will be disabled.
If a user selects nothing, or removes all the selections, the symbol and text tab will be disabled, and if the user is on one of them they will be moved to the modify tab (but will not if you're on the search or favorites tab).
Updated Add Symbol button visibility to not show whenever the user was modifying a symbol.