### PR TITLE
Fixing a bug with importing a JSON file

### DIFF
--- a/source/ProSymbolEditor/ViewModels/MilitarySymbolDockpaneViewModel.cs
+++ b/source/ProSymbolEditor/ViewModels/MilitarySymbolDockpaneViewModel.cs
@@ -1188,7 +1188,7 @@ namespace ProSymbolEditor
             openFileDialog.Filter = "JSON Files (*.json)|*.json";
             if (openFileDialog.ShowDialog() == true)
             {
-                if (Path.GetExtension(openFileDialog.FileName).ToUpper() == "JSON")
+                if (Path.GetExtension(openFileDialog.FileName).ToUpper() == ".JSON")
                 {
                     string json = File.ReadAllText(openFileDialog.FileName);
 


### PR DESCRIPTION
The last commit that I did introduced a bug where JSON favorite files couldn't be imported into the addin.  Bob alerted me to this since his jsons weren't importing correctly, and he thought it was an issue with them (it wasn't, they work fine with this change).  He asked that I make the easy code change (literally just missing one character).  Let me or Bob know if you have any questions.