### PR TITLE
Address #108 - Modify pane update on save edits

### DIFF
--- a/source/ProSymbolEditor/MapTools/SelectionMapTool.cs
+++ b/source/ProSymbolEditor/MapTools/SelectionMapTool.cs
@@ -50,10 +50,7 @@ namespace ProSymbolEditor
         {
             // Clear any previous selection using the built-in Pro button/command
             // TRICKY: Must be called here before the QueuedTask so runs on Main UI Thread
-            IPlugInWrapper wrapper = FrameworkApplication.GetPlugInWrapper("esri_mapping_clearSelectionButton");
-            var command = wrapper as ICommand;
-            if ((command != null) && command.CanExecute(null))
-                command.Execute(null);
+            ProSymbolUtilities.ClearMapSelection();
 
             return await QueuedTask.Run(() =>
             {

--- a/source/ProSymbolEditor/Utilities/ProSymbolUtilities.cs
+++ b/source/ProSymbolEditor/Utilities/ProSymbolUtilities.cs
@@ -243,5 +243,25 @@ namespace ProSymbolEditor
             return gdbPath;
         }
 
+        public static bool ClearMapSelection()
+        {
+            bool success = false;
+
+            // Note: Must be called on UI Thread
+            ArcGIS.Desktop.Framework.FrameworkApplication.Current.Dispatcher.Invoke(() =>
+            {
+                // Clear the feature selection using the built-in Pro button/command
+                ArcGIS.Desktop.Framework.IPlugInWrapper wrapper = 
+                    ArcGIS.Desktop.Framework.FrameworkApplication.GetPlugInWrapper("esri_mapping_clearSelectionButton");
+                var command = wrapper as System.Windows.Input.ICommand;
+                if ((command != null) && command.CanExecute(null))
+                {
+                    command.Execute(null);
+                    success = true;
+                }
+            });
+
+            return success;
+        }
     }
 }


### PR DESCRIPTION
Address #108: Modify pane symbol preview doesn't refresh once you save edits, by flashing/reselecting feature on save