### PR TITLE
Dark theme - change XCTK propertygrid to WPF datagrid

### DIFF
--- a/source/ProSymbolEditor/Models/SymbolAttributes/SymbolAttributeSet.cs
+++ b/source/ProSymbolEditor/Models/SymbolAttributes/SymbolAttributeSet.cs
@@ -132,6 +132,9 @@ namespace ProSymbolEditor
                     dict.Add(key, valueAsString);
                 }
 
+                if (!string.IsNullOrEmpty(StandardVersion))
+                    dict.Add("Standard", StandardVersion);
+
                 return dict;
             }
         }
@@ -865,20 +868,22 @@ namespace ProSymbolEditor
             SymbolTags = "";
 
             StandardVersion = ProSymbolUtilities.StandardString;
+
+            NotifyPropertyChanged(() => IsValid);
         }
 
         private void Attributes_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             GeneratePreviewSymbol();
 
-            // Tell the XCTK grid to get the updated label for this 
+            // Tell the proprties datagrids to get the updated info
             NotifyPropertyChanged(() => Name);
             NotifyPropertyChanged(() => AttributesDictionary);
         }
 
         private void LabelAttributes_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            // Tell the XCTK grid to get the updated label for this 
+            // Tell the proprties datagrids to get the updated info
             NotifyPropertyChanged(() => Name);
             NotifyPropertyChanged(() => AttributesDictionary);
         }

--- a/source/ProSymbolEditor/Models/SymbolAttributes/SymbolAttributeSet.cs
+++ b/source/ProSymbolEditor/Models/SymbolAttributes/SymbolAttributeSet.cs
@@ -51,6 +51,7 @@ namespace ProSymbolEditor
             DisplayAttributes.PropertyChanged += Attributes_PropertyChanged;
 
             LabelAttributes = new LabelAttributes();
+            LabelAttributes.PropertyChanged += LabelAttributes_PropertyChanged;
 
             StandardVersion = ProSymbolUtilities.StandardString;
         }
@@ -75,6 +76,64 @@ namespace ProSymbolEditor
                 return 0;
             else
                 return DisplayAttributes.GetHashCode() ^ LabelAttributes.GetHashCode();
+        }
+
+        [ScriptIgnore]
+        public Dictionary<string, string> AttributesDictionary
+        {
+            get
+            {
+
+                Dictionary<string, string> dict = new Dictionary<string, string>();
+
+                dict.Add("SymbolType", this.Name);
+
+                foreach (var prop in DisplayAttributes.GetType().GetProperties())
+                {
+                    string key = prop.Name;
+                    object value = prop.GetValue(DisplayAttributes, null);
+                    if (value == null)
+                        continue;
+
+                    string valueAsString = value.ToString();
+
+                    // Skip non-value types
+                    if (valueAsString.StartsWith("ProSymbolEditor"))
+                        continue;
+
+                    // If debug needed:
+                    // System.Diagnostics.Trace.WriteLine(string.Format("{0}={1}", key, valueAsString));
+
+                    if (string.IsNullOrEmpty(valueAsString) || dict.ContainsKey(key))
+                        continue;
+
+                    dict.Add(key, valueAsString);
+                }
+
+                foreach (var prop in LabelAttributes.GetType().GetProperties())
+                {
+                    string key = prop.Name;
+                    object value = prop.GetValue(LabelAttributes, null);
+                    if (value == null)
+                        continue;
+
+                    string valueAsString = value.ToString();
+
+                    // Skip non-value types
+                    if (valueAsString.StartsWith("ProSymbolEditor"))
+                        continue;
+
+                    // If debug needed:
+                    // System.Diagnostics.Trace.WriteLine(string.Format("{0}={1}", key, valueAsString));
+
+                    if (string.IsNullOrEmpty(valueAsString) || dict.ContainsKey(key))
+                        continue;
+
+                    dict.Add(key, valueAsString);
+                }
+
+                return dict;
+            }
         }
 
         #region Getters/Setters
@@ -814,6 +873,14 @@ namespace ProSymbolEditor
 
             // Tell the XCTK grid to get the updated label for this 
             NotifyPropertyChanged(() => Name);
+            NotifyPropertyChanged(() => AttributesDictionary);
+        }
+
+        private void LabelAttributes_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            // Tell the XCTK grid to get the updated label for this 
+            NotifyPropertyChanged(() => Name);
+            NotifyPropertyChanged(() => AttributesDictionary);
         }
     }
 }

--- a/source/ProSymbolEditor/Views/MilitarySymbolDockpane.xaml
+++ b/source/ProSymbolEditor/Views/MilitarySymbolDockpane.xaml
@@ -381,6 +381,16 @@
                                             VerticalAlignment="Stretch"
                                             ItemsSource="{Binding SelectedFeaturesCollection, UpdateSourceTrigger=PropertyChanged}"
                                             SelectedItem="{Binding SelectedSelectedFeature, Mode=TwoWay}">
+                                            <ListBox.Style>
+                                                <Style TargetType="ListBox" BasedOn="{StaticResource {x:Type ListBox}}">
+                                                    <Setter Property="Visibility" Value="Visible" />
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding SelectedFeaturesCollection.Count}" Value="0">
+                                                            <Setter Property="Visibility" Value="Collapsed" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </ListBox.Style>
 
                                             <ListBox.ItemsPanel>
                                                 <ItemsPanelTemplate>

--- a/source/ProSymbolEditor/Views/MilitarySymbolDockpane.xaml
+++ b/source/ProSymbolEditor/Views/MilitarySymbolDockpane.xaml
@@ -1559,7 +1559,22 @@
                                             </Image.ContextMenu>
                                         </Image>
 
-                                        <xctk:PropertyGrid
+                                        <DataGrid 
+                                            Grid.Row="1"
+                                            Height="150"
+                                            Margin="5,5,5,5"                                       
+                                            ItemsSource="{Binding SymbolAttributeSet.AttributesDictionary}" 
+                                            Style="{DynamicResource Esri_DataGridStyle}" 
+                                            ToolTip="{Binding SymbolAttributeSet.Name}" 
+                                            HeadersVisibility="Column" 
+                                            RowHeaderWidth="0" >
+                                            <DataGrid.Columns>
+                                                <DataGridTextColumn Header="Attribute" Binding="{Binding Key}" />
+                                                <DataGridTextColumn Header="Value" Binding="{Binding Value}" />
+                                            </DataGrid.Columns>
+                                        </DataGrid>
+                                        
+                                        <!--<xctk:PropertyGrid
                                             Grid.Row="1"
                                             Height="150"
                                             Margin="5,5,5,5"
@@ -1571,7 +1586,7 @@
                                             ShowSearchBox="False"
                                             ShowSortOptions="False"
                                             ShowSummary="False"
-                                            ToolTip="{Binding SymbolAttributeSet.Name}">
+                                            >
                                             <xctk:PropertyGrid.PropertyDefinitions>
                                                 <xctk:PropertyDefinition
                                                     DisplayName="Name"
@@ -1590,7 +1605,7 @@
                                                     DisplayOrder="3"
                                                     TargetProperties="StandardVersion" />
                                             </xctk:PropertyGrid.PropertyDefinitions>
-                                        </xctk:PropertyGrid>
+                                        </xctk:PropertyGrid>-->
                                     </Grid>
                                 </StackPanel>
                             </ScrollViewer>

--- a/source/ProSymbolEditor/Views/MilitarySymbolDockpane.xaml
+++ b/source/ProSymbolEditor/Views/MilitarySymbolDockpane.xaml
@@ -154,6 +154,7 @@
                                             HorizontalAlignment="Right"
                                             HorizontalContentAlignment="Center"
                                             VerticalContentAlignment="Center"
+                                            Foreground="{DynamicResource Esri_TextControlBrush}" 
                                             Background="{Binding Backgound, ElementName=searchSymbolsTextBox}"
                                             Command="{Binding ClearSearchTextCommand}"
                                             Content="X" />
@@ -1200,12 +1201,9 @@
                                     Width="82"
                                     Height="24"
                                     HorizontalAlignment="Center"
-                                    Background="White"
-                                    BorderBrush="Black"
-                                    BorderThickness="0.5"
                                     Command="{Binding SaveEditsCommand}"
                                     Content="Save Edits"
-                                    Foreground="Black"
+                                    Style="{DynamicResource Esri_SimpleButton}"
                                     ToolTip="Save Edits"
                                     Visibility="{Binding Path=IsEditing, Converter={StaticResource BoolToVis}}" />
                                 <Button
@@ -1584,12 +1582,9 @@
                                     Width="82"
                                     Height="24"
                                     HorizontalAlignment="Center"
-                                    Background="White"
-                                    BorderBrush="Black"
-                                    BorderThickness="0.5"
                                     Command="{Binding SaveEditsCommand}"
                                     Content="Save Edits"
-                                    Foreground="Black"
+                                    Style="{DynamicResource Esri_SimpleButton}"
                                     ToolTip="Save Edits"
                                     Visibility="{Binding Path=IsEditing, Converter={StaticResource BoolToVis}}" />
                                 <Button
@@ -1762,11 +1757,9 @@
                                     Width="101"
                                     Height="24"
                                     HorizontalAlignment="Center"
-                                    Background="White"
-                                    BorderBrush="Black"
-                                    BorderThickness="0.5"
                                     Command="{Binding SaveEditsCommand}"
                                     Content="Save Edits"
+                                    Style="{DynamicResource Esri_SimpleButton}"
                                     ToolTip="Save Edits"
                                     Visibility="{Binding Path=IsEditing, Converter={StaticResource BoolToVis}}" />
                             </Grid>

--- a/source/ProSymbolEditor/Views/MilitarySymbolDockpane.xaml
+++ b/source/ProSymbolEditor/Views/MilitarySymbolDockpane.xaml
@@ -458,37 +458,25 @@
                                             </Image.ContextMenu>
                                         </Image>
 
-                                        <xctk:PropertyGrid
+                                        <DataGrid 
                                             Grid.Row="1"
                                             Height="150"
-                                            Margin="5,5,5,5"
-                                            AutoGenerateProperties="False"
-                                            Foreground="Black"
-                                            IsCategorized="False"
-                                            IsReadOnly="True"
-                                            SelectedObject="{Binding EditSelectedFeatureSymbol}"
-                                            ShowSearchBox="False"
-                                            ShowSortOptions="False"
-                                            ShowSummary="False">
-                                            <xctk:PropertyGrid.PropertyDefinitions>
-                                                <xctk:PropertyDefinition
-                                                    DisplayName="Name"
-                                                    DisplayOrder="0"
-                                                    TargetProperties="Name" />
-                                                <xctk:PropertyDefinition
-                                                    DisplayName="Display Attributes"
-                                                    DisplayOrder="1"
-                                                    TargetProperties="DisplayAttributes" />
-                                                <xctk:PropertyDefinition
-                                                    DisplayName="Label Attributes"
-                                                    DisplayOrder="2"
-                                                    TargetProperties="LabelAttributes" />
-                                                <xctk:PropertyDefinition
-                                                    DisplayName="Standard"
-                                                    DisplayOrder="3"
-                                                    TargetProperties="StandardVersion" />
-                                            </xctk:PropertyGrid.PropertyDefinitions>
-                                        </xctk:PropertyGrid>
+                                            Margin="5,5,5,5"                                       
+                                            ItemsSource="{Binding EditSelectedFeatureSymbol.AttributesDictionary}" 
+                                            Style="{DynamicResource Esri_DataGridStyle}" 
+                                            HeadersVisibility="Column" 
+                                            RowHeaderWidth="0" 
+                                            Visibility="{Binding EditSelectedFeatureSymbol.IsValid, Converter={StaticResource BoolToVis}, FallbackValue=Collapsed}">
+                                            <DataGrid.ToolTip>
+                                                <ToolTip Background="{DynamicResource Esri_ControlBackgroundBrush}">
+                                                    <TextBlock Text="{Binding SymbolAttributeSet.Name}" Style="{DynamicResource RegularText}" />
+                                                </ToolTip>
+                                            </DataGrid.ToolTip>                                            
+                                            <DataGrid.Columns>
+                                                <DataGridTextColumn Header="Attribute" Binding="{Binding Key}" />
+                                                <DataGridTextColumn Header="Value" Binding="{Binding Value}" />
+                                            </DataGrid.Columns>
+                                        </DataGrid>
 
                                     </Grid>
                                 </StackPanel>
@@ -725,38 +713,25 @@
                                             </Image.ContextMenu>
                                         </Image>
 
-                                        <xctk:PropertyGrid
+                                        <DataGrid 
                                             Grid.Row="1"
                                             Height="150"
-                                            Margin="5,5,5,5"
-                                            AutoGenerateProperties="False"
-                                            Foreground="Black"
-                                            IsCategorized="False"
-                                            IsReadOnly="True"
-                                            SelectedObject="{Binding SelectedFavoriteSymbol}"
-                                            ShowSearchBox="False"
-                                            ShowSortOptions="False"
-                                            ShowSummary="False">
-                                            <xctk:PropertyGrid.PropertyDefinitions>
-                                                <xctk:PropertyDefinition
-                                                    DisplayName="Name"
-                                                    DisplayOrder="0"
-                                                    TargetProperties="Name" />
-                                                <xctk:PropertyDefinition
-                                                    DisplayName="Display Attributes"
-                                                    DisplayOrder="1"
-                                                    TargetProperties="DisplayAttributes" />
-                                                <xctk:PropertyDefinition
-                                                    DisplayName="Label Attributes"
-                                                    DisplayOrder="2"
-                                                    TargetProperties="LabelAttributes" />
-                                                <xctk:PropertyDefinition
-                                                    DisplayName="Standard"
-                                                    DisplayOrder="3"
-                                                    TargetProperties="StandardVersion" />
-                                            </xctk:PropertyGrid.PropertyDefinitions>
-                                        </xctk:PropertyGrid>
-
+                                            Margin="5,5,5,5"                                       
+                                            ItemsSource="{Binding SelectedFavoriteSymbol.AttributesDictionary}" 
+                                            Style="{DynamicResource Esri_DataGridStyle}" 
+                                            HeadersVisibility="Column" 
+                                            RowHeaderWidth="0" >
+                                            <DataGrid.ToolTip>
+                                                <ToolTip Background="{DynamicResource Esri_ControlBackgroundBrush}">
+                                                    <TextBlock Text="{Binding SymbolAttributeSet.Name}" Style="{DynamicResource RegularText}" />
+                                                </ToolTip>
+                                            </DataGrid.ToolTip>
+                                            <DataGrid.Columns>
+                                                <DataGridTextColumn Header="Attribute" Binding="{Binding Key}" />
+                                                <DataGridTextColumn Header="Value" Binding="{Binding Value}" />
+                                            </DataGrid.Columns>
+                                        </DataGrid>
+                                        
                                     </Grid>
                                 </StackPanel>
                             </ScrollViewer>
@@ -1157,38 +1132,24 @@
                                             </Image.ContextMenu>
                                         </Image>
 
-                                        <xctk:PropertyGrid
+                                        <DataGrid 
                                             Grid.Row="1"
                                             Height="150"
-                                            Margin="5,5,5,5"
-                                            AutoGenerateProperties="False"
-                                            Foreground="Black"
-                                            IsCategorized="False"
-                                            IsReadOnly="True"
-                                            SelectedObject="{Binding SymbolAttributeSet}"
-                                            ShowSearchBox="False"
-                                            ShowSortOptions="False"
-                                            ShowSummary="False"
-                                            ToolTip="{Binding SymbolAttributeSet.Name}">
-                                            <xctk:PropertyGrid.PropertyDefinitions>
-                                                <xctk:PropertyDefinition
-                                                    DisplayName="Name"
-                                                    DisplayOrder="0"
-                                                    TargetProperties="Name" />
-                                                <xctk:PropertyDefinition
-                                                    DisplayName="Display Attributes"
-                                                    DisplayOrder="1"
-                                                    TargetProperties="DisplayAttributes" />
-                                                <xctk:PropertyDefinition
-                                                    DisplayName="Label Attributes"
-                                                    DisplayOrder="2"
-                                                    TargetProperties="LabelAttributes" />
-                                                <xctk:PropertyDefinition
-                                                    DisplayName="Standard"
-                                                    DisplayOrder="3"
-                                                    TargetProperties="StandardVersion" />
-                                            </xctk:PropertyGrid.PropertyDefinitions>
-                                        </xctk:PropertyGrid>
+                                            Margin="5,5,5,5"                                       
+                                            ItemsSource="{Binding SymbolAttributeSet.AttributesDictionary}" 
+                                            Style="{DynamicResource Esri_DataGridStyle}"
+                                            HeadersVisibility="Column" 
+                                            RowHeaderWidth="0" >
+                                            <DataGrid.ToolTip>
+                                                <ToolTip Background="{DynamicResource Esri_ControlBackgroundBrush}">
+                                                    <TextBlock Text="{Binding SymbolAttributeSet.Name}" Style="{DynamicResource RegularText}" />
+                                                </ToolTip>
+                                            </DataGrid.ToolTip>                                            
+                                            <DataGrid.Columns>
+                                                <DataGridTextColumn Header="Attribute" Binding="{Binding Key}" />
+                                                <DataGridTextColumn Header="Value" Binding="{Binding Value}" />
+                                            </DataGrid.Columns>
+                                        </DataGrid>                                        
 
                                     </Grid>
                                 </StackPanel>
@@ -1565,47 +1526,18 @@
                                             Margin="5,5,5,5"                                       
                                             ItemsSource="{Binding SymbolAttributeSet.AttributesDictionary}" 
                                             Style="{DynamicResource Esri_DataGridStyle}" 
-                                            ToolTip="{Binding SymbolAttributeSet.Name}" 
                                             HeadersVisibility="Column" 
                                             RowHeaderWidth="0" >
+                                            <DataGrid.ToolTip>
+                                                <ToolTip Background="{DynamicResource Esri_ControlBackgroundBrush}">
+                                                    <TextBlock Text="{Binding SymbolAttributeSet.Name}" Style="{DynamicResource RegularText}" />
+                                                </ToolTip>
+                                            </DataGrid.ToolTip>                                            
                                             <DataGrid.Columns>
                                                 <DataGridTextColumn Header="Attribute" Binding="{Binding Key}" />
                                                 <DataGridTextColumn Header="Value" Binding="{Binding Value}" />
                                             </DataGrid.Columns>
                                         </DataGrid>
-                                        
-                                        <!--<xctk:PropertyGrid
-                                            Grid.Row="1"
-                                            Height="150"
-                                            Margin="5,5,5,5"
-                                            AutoGenerateProperties="False"
-                                            Foreground="Black"
-                                            IsCategorized="False"
-                                            IsReadOnly="True"
-                                            SelectedObject="{Binding SymbolAttributeSet}"
-                                            ShowSearchBox="False"
-                                            ShowSortOptions="False"
-                                            ShowSummary="False"
-                                            >
-                                            <xctk:PropertyGrid.PropertyDefinitions>
-                                                <xctk:PropertyDefinition
-                                                    DisplayName="Name"
-                                                    DisplayOrder="0"
-                                                    TargetProperties="Name" />
-                                                <xctk:PropertyDefinition
-                                                    DisplayName="Display Attributes"
-                                                    DisplayOrder="1"
-                                                    TargetProperties="DisplayAttributes" />
-                                                <xctk:PropertyDefinition
-                                                    DisplayName="Label Attributes"
-                                                    DisplayOrder="2"
-                                                    TargetProperties="LabelAttributes" />
-                                                <xctk:PropertyDefinition
-                                                    DisplayName="Standard"
-                                                    DisplayOrder="3"
-                                                    TargetProperties="StandardVersion" />
-                                            </xctk:PropertyGrid.PropertyDefinitions>
-                                        </xctk:PropertyGrid>-->
                                     </Grid>
                                 </StackPanel>
                             </ScrollViewer>
@@ -1766,38 +1698,25 @@
                                             </Image.ContextMenu>
                                         </Image>
 
-                                        <xctk:PropertyGrid
+                                        <DataGrid 
                                             Grid.Row="1"
                                             Height="150"
-                                            Margin="5,5,5,5"
-                                            AutoGenerateProperties="False"
-                                            Foreground="Black"
-                                            IsCategorized="False"
-                                            IsReadOnly="True"
-                                            SelectedObject="{Binding SymbolAttributeSet}"
-                                            ShowSearchBox="False"
-                                            ShowSortOptions="False"
-                                            ShowSummary="False"
-                                            ToolTip="{Binding SymbolAttributeSet.Name}">
-                                            <xctk:PropertyGrid.PropertyDefinitions>
-                                                <xctk:PropertyDefinition
-                                                    DisplayName="Name"
-                                                    DisplayOrder="0"
-                                                    TargetProperties="Name" />
-                                                <xctk:PropertyDefinition
-                                                    DisplayName="Display Attributes"
-                                                    DisplayOrder="1"
-                                                    TargetProperties="DisplayAttributes" />
-                                                <xctk:PropertyDefinition
-                                                    DisplayName="Label Attributes"
-                                                    DisplayOrder="2"
-                                                    TargetProperties="LabelAttributes" />
-                                                <xctk:PropertyDefinition
-                                                    DisplayName="Standard"
-                                                    DisplayOrder="3"
-                                                    TargetProperties="StandardVersion" />
-                                            </xctk:PropertyGrid.PropertyDefinitions>
-                                        </xctk:PropertyGrid>
+                                            Margin="5,5,5,5"                                       
+                                            ItemsSource="{Binding SymbolAttributeSet.AttributesDictionary}" 
+                                            Style="{DynamicResource Esri_DataGridStyle}" 
+                                            HeadersVisibility="Column" 
+                                            RowHeaderWidth="0" >
+                                            <DataGrid.ToolTip>
+                                                <ToolTip Background="{DynamicResource Esri_ControlBackgroundBrush}">
+                                                    <TextBlock Text="{Binding SymbolAttributeSet.Name}" Style="{DynamicResource RegularText}" />
+                                                </ToolTip>
+                                            </DataGrid.ToolTip>                                            
+                                            <DataGrid.Columns>
+                                                <DataGridTextColumn Header="Attribute" Binding="{Binding Key}" />
+                                                <DataGridTextColumn Header="Value" Binding="{Binding Value}" />
+                                            </DataGrid.Columns>
+                                        </DataGrid>
+
                                     </Grid>
                                 </StackPanel>
                             </ScrollViewer>


### PR DESCRIPTION
Changed 3rd party WPFTools propertygrid (no dark theme support in OpenSource version) to standard WPF datagrid (which Pro provides dark theme style for) to address issues with previous propertygrid in Dark Theme

See #163, #164, #166, #167, #188 
