### PR TITLE
Change link button style to match Pro Standard Text

### DIFF
--- a/source/ProSymbolEditor/Views/MilitarySymbolDockpane.xaml
+++ b/source/ProSymbolEditor/Views/MilitarySymbolDockpane.xaml
@@ -1793,10 +1793,10 @@
                         </Button.Template>
                         <Button.Style>
                             <Style TargetType="Button">
-                                <Setter Property="Foreground" Value="Blue" />
+                                <Setter Property="Foreground" Value="{DynamicResource Esri_TextControlBrush}" />
                                 <Style.Triggers>
                                     <Trigger Property="IsMouseOver" Value="true">
-                                        <Setter Property="Foreground" Value="Red" />
+                                        <Setter Property="Foreground" Value="{DynamicResource Esri_TextSelectionHighlightBrush}" />
                                     </Trigger>
                                 </Style.Triggers>
                             </Style>
@@ -1816,10 +1816,10 @@
                         </Button.Template>
                         <Button.Style>
                             <Style TargetType="Button">
-                                <Setter Property="Foreground" Value="Blue" />
+                                <Setter Property="Foreground" Value="{DynamicResource Esri_TextControlBrush}" />
                                 <Style.Triggers>
                                     <Trigger Property="IsMouseOver" Value="true">
-                                        <Setter Property="Foreground" Value="Red" />
+                                        <Setter Property="Foreground" Value="{DynamicResource Esri_TextSelectionHighlightBrush}" />
                                     </Trigger>
                                 </Style.Triggers>
                             </Style>


### PR DESCRIPTION
Address #248 to fix button style to match Pro standard text in Light/Dark theme:

Before this change (Dark):
![image](https://user-images.githubusercontent.com/5488313/42329047-dae233e4-803d-11e8-8a85-c8d46be7ceef.png)

After:

Dark:
![image](https://user-images.githubusercontent.com/3090809/43534415-4bec9e6a-9585-11e8-9ff6-54e3704425d9.png)

Dark Hover/Select:
![image](https://user-images.githubusercontent.com/3090809/43534598-c09adbdc-9585-11e8-845f-1ad4c451bce4.png)

Light:
![image](https://user-images.githubusercontent.com/3090809/43534499-8097fc18-9585-11e8-9e4d-b3c610a81e4a.png)

