### PR TITLE
#247 - Workaround for Back Button Gray Background in Dark Theme

### DIFF
--- a/source/ProSymbolEditor/Views/MilitarySymbolDockpane.xaml
+++ b/source/ProSymbolEditor/Views/MilitarySymbolDockpane.xaml
@@ -2,13 +2,13 @@
     x:Class="ProSymbolEditor.MilitarySymbolDockpaneView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:Controls="clr-namespace:ArcGIS.Desktop.Extensions.Controls;assembly=ArcGIS.Desktop.Extensions"
-    xmlns:extensions="clr-namespace:ArcGIS.Desktop.Extensions;assembly=ArcGIS.Desktop.Extensions"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"         
+    xmlns:controls="clr-namespace:ArcGIS.Desktop.Extensions.Controls;assembly=ArcGIS.Desktop.Extensions"
+    xmlns:extensions="clr-namespace:ArcGIS.Desktop.Extensions;assembly=ArcGIS.Desktop.Extensions"
     xmlns:local="clr-namespace:ProSymbolEditor"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
-    xmlns:sys="clr-namespace:System;assembly=mscorlib"    
+    xmlns:sys="clr-namespace:System;assembly=mscorlib"
     d:DesignHeight="430"
     d:DesignWidth="550"
     mc:Ignorable="d">
@@ -319,15 +319,15 @@
                                 <Button
                                     x:Name="modifyButton"
                                     Grid.Column="2"
-                                    Margin="0,0,-26,0"
+                                    Margin="0,0,-10,10"                                    
                                     HorizontalAlignment="Right"
                                     Command="{Binding GoToTabCommand}"
                                     CommandParameter="3"
                                     IsEnabled="{Binding IsStyleItemSelected}"
-                                    Style="{DynamicResource Esri_BackButton}"
+                                    Style="{DynamicResource Esri_ButtonBackSmall}"
                                     ToolTip="Go to Symbol Tab">
                                     <Button.RenderTransform>
-                                        <ScaleTransform ScaleX="-1" />
+                                        <ScaleTransform ScaleX="-1.5" ScaleY="1.5"/>
                                     </Button.RenderTransform>
                                 </Button>
                             </Grid>
@@ -502,15 +502,15 @@
 
                                 <Button
                                     Grid.Column="2"
-                                    Margin="0,0,-26,0"
+                                    Margin="0,0,-10,10"
                                     HorizontalAlignment="Right"
                                     Command="{Binding GoToTabCommand}"
                                     CommandParameter="3"
                                     IsEnabled="{Binding IsStyleItemSelected}"
-                                    Style="{DynamicResource Esri_BackButton}"
+                                    Style="{DynamicResource Esri_ButtonBackSmall}"
                                     ToolTip="Go to Symbol Tab">
                                     <Button.RenderTransform>
-                                        <ScaleTransform ScaleX="-1" />
+                                        <ScaleTransform ScaleX="-1.5" ScaleY="1.5"/>
                                     </Button.RenderTransform>
                                 </Button>
                             </Grid>
@@ -758,11 +758,16 @@
                                 <Button
                                     Grid.Row="0"
                                     Grid.Column="0"
+                                    Margin="0,0,-10,10"
                                     HorizontalAlignment="Left"
                                     Command="{Binding GoToTabCommand}"
                                     CommandParameter="0"
-                                    Style="{DynamicResource Esri_BackButton}"
-                                    ToolTip="Back to Search" />
+                                    Style="{DynamicResource Esri_ButtonBackSmall}"
+                                    ToolTip="Back to Search" >
+                                    <Button.RenderTransform>
+                                        <ScaleTransform ScaleX="1.5" ScaleY="1.5"/>
+                                    </Button.RenderTransform>
+                                </Button>
                                 <Button
                                     Grid.Row="0"
                                     Grid.Column="1"
@@ -792,14 +797,14 @@
                                 <Button
                                     Grid.Row="0"
                                     Grid.Column="3"
-                                    Margin="0,0,-26,0"
+                                    Margin="0,0,-10,10"                                    
                                     HorizontalAlignment="Right"
                                     Command="{Binding GoToTabCommand}"
                                     CommandParameter="3"
-                                    Style="{DynamicResource Esri_BackButton}"
+                                    Style="{DynamicResource Esri_ButtonBackSmall}"
                                     ToolTip="Go to Symbol Tab">
                                     <Button.RenderTransform>
-                                        <ScaleTransform ScaleX="-1" />
+                                        <ScaleTransform ScaleX="-1.5" ScaleY="1.5"/>
                                     </Button.RenderTransform>
                                 </Button>
                             </Grid>
@@ -1176,11 +1181,16 @@
                                 <Button
                                     Grid.Row="0"
                                     Grid.Column="0"
+                                    Margin="0,0,-10,10"
                                     HorizontalAlignment="Left"
                                     Command="{Binding GoToTabCommand}"
                                     CommandParameter="0"
-                                    Style="{DynamicResource Esri_BackButton}"
-                                    ToolTip="Back to Search" />
+                                    Style="{DynamicResource Esri_ButtonBackSmall}"
+                                    ToolTip="Back to Search">
+                                    <Button.RenderTransform>
+                                        <ScaleTransform ScaleX="1.5" ScaleY="1.5"/>
+                                    </Button.RenderTransform>
+                                </Button>                                    
                                 <Button
                                     Grid.Row="0"
                                     Grid.Column="1"
@@ -1219,14 +1229,14 @@
                                 <Button
                                     Grid.Row="0"
                                     Grid.Column="3"
-                                    Margin="0,0,-26,0"
+                                    Margin="0,0,-10,10"                                    
                                     HorizontalAlignment="Right"
                                     Command="{Binding GoToTabCommand}"
                                     CommandParameter="4"
-                                    Style="{DynamicResource Esri_BackButton}"
+                                    Style="{DynamicResource Esri_ButtonBackSmall}"
                                     ToolTip="Go to Label Tab">
                                     <Button.RenderTransform>
-                                        <ScaleTransform ScaleX="-1" />
+                                        <ScaleTransform ScaleX="-1.5" ScaleY="1.5"/>
                                     </Button.RenderTransform>
                                 </Button>
 
@@ -1561,10 +1571,15 @@
                                 <Button
                                     Grid.Column="0"
                                     HorizontalAlignment="Left"
+                                    Margin="0,0,-10,10"                                    
                                     Command="{Binding GoToTabCommand}"
                                     CommandParameter="3"
-                                    Style="{DynamicResource Esri_BackButton}"
-                                    ToolTip="Back to Symbol" />
+                                    Style="{DynamicResource Esri_ButtonBackSmall}"
+                                    ToolTip="Back to Symbol">
+                                    <Button.RenderTransform>
+                                        <ScaleTransform ScaleX="1.5" ScaleY="1.5"/>
+                                    </Button.RenderTransform>
+                                </Button>                                    
                                 <Button
                                     Grid.Column="1"
                                     Width="90"
@@ -1599,15 +1614,15 @@
                                     Visibility="{Binding Path=IsEditing, Converter={StaticResource BoolToVis}}" />
                                 <Button
                                     Grid.Column="3"
-                                    Margin="0,0,-26,0"
+                                    Margin="0,0,-10,10"                                    
                                     HorizontalAlignment="Right"
                                     Command="{Binding GoToTabCommand}"
                                     CommandParameter="5"
                                     IsEnabled="{Binding IsCoordinateTabEnabled}"
-                                    Style="{DynamicResource Esri_BackButton}"
+                                    Style="{DynamicResource Esri_ButtonBackSmall}"
                                     ToolTip="Enter Coordinates">
                                     <Button.RenderTransform>
-                                        <ScaleTransform ScaleX="-1" />
+                                        <ScaleTransform ScaleX="-1.5" ScaleY="1.5"/>
                                     </Button.RenderTransform>
                                 </Button>
                             </Grid>
@@ -1735,11 +1750,16 @@
 
                                 <Button
                                     Grid.Column="0"
+                                    Margin="0,0,-10,10"                                    
                                     HorizontalAlignment="Left"
                                     Command="{Binding GoToTabCommand}"
                                     CommandParameter="4"
-                                    Style="{DynamicResource Esri_BackButton}"
-                                    ToolTip="Back to Label" />
+                                    Style="{DynamicResource Esri_ButtonBackSmall}"
+                                    ToolTip="Back to Label" >
+                                    <Button.RenderTransform>
+                                        <ScaleTransform ScaleX="1.5" ScaleY="1.5"/>
+                                    </Button.RenderTransform>
+                                </Button>
                                 <Button
                                     Grid.Column="1"
                                     Width="90"

--- a/source/ProSymbolEditor/Views/MilitarySymbolDockpane.xaml.cs
+++ b/source/ProSymbolEditor/Views/MilitarySymbolDockpane.xaml.cs
@@ -16,7 +16,6 @@
 
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Controls.Primitives;
 using System.Windows.Media;
 
 namespace ProSymbolEditor


### PR DESCRIPTION
#247 - Workaround for Back Button Gray Background in Dark Theme

This is an issue with the Pro-provided "Esri_ButtonBack" - the workaround was just to substitute the working small version("Esri_ButtonBackSmall" and scale it to a larger size.

Should look like this 

Before:

![image](https://user-images.githubusercontent.com/3090809/43553941-8b305e9c-95bf-11e8-87bb-28e7cbea3686.png)

After:

![image](https://user-images.githubusercontent.com/3090809/43553953-9331c28e-95bf-11e8-86bb-34e8c509126c.png)


