### PR TITLE
#246 - Remove Gray Background from Select Tool

### DIFF
--- a/source/ProSymbolEditor/Views/MilitarySymbolDockpane.xaml
+++ b/source/ProSymbolEditor/Views/MilitarySymbolDockpane.xaml
@@ -363,11 +363,35 @@
                                                 Grid.Column="1"
                                                 Margin="2,0,0,0"
                                                 Command="{Binding SelectToolCommand}"
-                                                IsChecked="{Binding SelectToolEnabled}">
+                                                IsChecked="{Binding SelectToolEnabled}"
+                                                Focusable="False">
                                                 <Image
                                                     HorizontalAlignment="Center"
                                                     VerticalAlignment="Center"
                                                     Source="pack://application:,,,/MilitarySymbolEditor;component/Images/SelectionSelectTool16.png" />
+                                                <ToggleButton.Style>
+                                                    <Style TargetType="{x:Type ToggleButton}" BasedOn="{StaticResource {x:Type ToggleButton}}">
+                                                        <Setter Property="Background" Value="Transparent"/>
+                                                        <Setter Property="BorderBrush" Value="Transparent"/>
+                                                        <Setter Property="Width" Value="20"/>
+                                                        <Setter Property="Height" Value="20"/>
+                                                        <Setter Property="Padding" Value="1"/>
+                                                        <Style.Triggers>
+                                                            <Trigger Property="IsEnabled" Value="false">
+                                                                <Setter Property="Opacity" Value="0.5"/>
+                                                                <Setter Property="BorderBrush" Value="Transparent"/>
+                                                                <Setter Property="Background" Value="Transparent"/>
+                                                                <Setter Property="Template">
+                                                                    <Setter.Value>
+                                                                        <ControlTemplate TargetType="{x:Type ToggleButton}">
+                                                                            <ContentPresenter Margin="2" HorizontalAlignment="{TemplateBinding Control.HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding Control.VerticalContentAlignment}" SnapsToDevicePixels="{TemplateBinding UIElement.SnapsToDevicePixels}" ContentTemplate="{TemplateBinding ContentControl.ContentTemplate}" RecognizesAccessKey="True" Content="{TemplateBinding ContentControl.Content}" />
+                                                                        </ControlTemplate>
+                                                                    </Setter.Value>
+                                                                </Setter>
+                                                            </Trigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </ToggleButton.Style>
                                             </ToggleButton>
                                         </Grid>
 


### PR DESCRIPTION
Address #246 - Remove Gray Background from Select Tool in Dark Mode when tool is not toggled/selected

Addressed by:

1. Changing styling for background/border
2. Removing focus from button (it was the only button so got focus by default) 

Before:

![image](https://user-images.githubusercontent.com/5488313/42328114-8202e7a2-803b-11e8-8c89-920d96288252.png)

After:

Button Dark (not pressed/toggled):

![selectnotoggled](https://user-images.githubusercontent.com/3090809/43597508-44143c2c-9650-11e8-84fb-42bca23d7d7e.PNG)

Button Light (not pressed/toggled):

![selectnotoggled-light](https://user-images.githubusercontent.com/3090809/43597512-47674d60-9650-11e8-9414-23ebbb09f12b.PNG)
