### PR TITLE
#242 Removing Military Overlay Layers locks up addin+Pro

### DIFF
--- a/source/ProSymbolEditor/Models/MilitaryOverlayDataModel.cs
+++ b/source/ProSymbolEditor/Models/MilitaryOverlayDataModel.cs
@@ -148,7 +148,7 @@ namespace ProSymbolEditor
         {
             string activeGdbPath = DatabaseName;
 
-            IEnumerable<FeatureLayer> mapLayers = MapView.Active.Map.GetLayersAsFlattenedList().OfType<FeatureLayer>(); ;
+            IEnumerable<FeatureLayer> mapLayers = MapView.Active.Map.GetLayersAsFlattenedList().OfType<FeatureLayer>();
 
             bool isFeatureClassInActiveView = false;
 
@@ -198,6 +198,31 @@ namespace ProSymbolEditor
             return isFeatureClassInActiveView;
         }
 
+        public bool IsMilitaryOverlayInActiveMap()
+        {
+            // See if Active Map
+            if (MapView.Active == null)
+                return false; //No active map
+
+            // See if Military Overlay in Active Map
+            const string militaryOverlayName = "Military Overlay";
+            IEnumerable<GroupLayer> mapLayers = MapView.Active.Map.GetLayersAsFlattenedList().OfType<GroupLayer>().Where(l => l.Name.StartsWith(militaryOverlayName));
+            if ((mapLayers == null) || (mapLayers.Count() == 0))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public async Task<bool> IsMapActiveAndAddInEnabledAsync()
+        {
+            if (!IsMilitaryOverlayInActiveMap())
+                return await Task.FromResult<bool>(false);
+
+            return await ShouldAddInBeEnabledAsync(ProSymbolUtilities.Standard);
+        }
+
         public async Task<bool> ShouldAddInBeEnabledAsync()
         {
             return await ShouldAddInBeEnabledAsync(ProSymbolUtilities.Standard);
@@ -222,7 +247,7 @@ namespace ProSymbolEditor
                 {
                     foreach (GDBProjectItem gdbProjectItem in gdbProjectItems)
                     {
-                        if (gdbProjectItem.Name == "Map") // ignore the project Map GDB
+                        if (gdbProjectItem.Name == "map.gdb") // ignore the project Map GDB
                             continue;
 
                         using (Datastore datastore = gdbProjectItem.GetDatastore())

--- a/source/ProSymbolEditor/Models/MilitaryOverlayDataModel.cs
+++ b/source/ProSymbolEditor/Models/MilitaryOverlayDataModel.cs
@@ -198,6 +198,36 @@ namespace ProSymbolEditor
             return isFeatureClassInActiveView;
         }
 
+        public async Task<bool> AddFeatureClassToActiveView(string featureClassName)
+        {
+            if (string.IsNullOrEmpty(featureClassName) || string.IsNullOrEmpty(DatabaseName))
+                return await Task.FromResult<bool>(false);
+
+            bool layerAdded = false;
+
+            await ArcGIS.Desktop.Framework.Threading.Tasks.QueuedTask.Run(() =>
+            {
+                string uri = $@"{DatabaseName}\{ProSymbolUtilities.GetDatasetName()}\{featureClassName}";
+                Item currentItem = ItemFactory.Instance.Create(uri);
+                if (LayerFactory.Instance.CanCreateLayerFrom(currentItem))
+                {
+                    FeatureLayer fl = LayerFactory.Instance.CreateLayer(currentItem, 
+                        MapView.Active.Map) as FeatureLayer;
+
+                    if (fl != null)
+                    {
+                        ArcGIS.Core.CIM.CIMDictionaryRenderer dictionaryRenderer =
+                            ProSymbolUtilities.CreateDictionaryRenderer();
+                        fl.SetRenderer(dictionaryRenderer);
+
+                        layerAdded = true;
+                    }
+                }
+            });
+
+            return await Task.FromResult<bool>(layerAdded);
+        }
+
         public bool IsMilitaryOverlayInActiveMap()
         {
             // See if Active Map

--- a/source/ProSymbolEditor/Models/SymbolAttributes/SymbolAttributeSet.cs
+++ b/source/ProSymbolEditor/Models/SymbolAttributes/SymbolAttributeSet.cs
@@ -244,7 +244,7 @@ namespace ProSymbolEditor
             return ArcGIS.Desktop.Framework.Threading.Tasks.QueuedTask.Run(() => {
                 try
                 {
-                    string standard = "mil" + ProSymbolUtilities.StandardString.ToLower();
+                    string standard = ProSymbolUtilities.GetDictionaryString();
                     ArcGIS.Core.CIM.CIMSymbol symbol = ArcGIS.Desktop.Mapping.SymbolFactory.Instance.GetDictionarySymbol(standard, attributes);
 
                     if (symbol == null)

--- a/source/ProSymbolEditor/Utilities/ProSymbolUtilities.cs
+++ b/source/ProSymbolEditor/Utilities/ProSymbolUtilities.cs
@@ -72,6 +72,19 @@ namespace ProSymbolEditor
                 return "2525D";
         }
 
+        public static string GetDictionaryString()
+        {
+            return "mil" + StandardString.ToLower();
+        }
+
+        public static string GetDatasetName()
+        {
+            if (Standard == SupportedStandardsType.mil2525c_b2)
+                return "militaryoverlay2525b2";
+            else
+                return "militaryoverlay2525d";
+        }
+
         public static string NameSeparator
         {
             get { return " : "; }
@@ -319,6 +332,66 @@ namespace ProSymbolEditor
             }
 
             return geometryType;
+        }
+
+        private static Dictionary<string, string> fieldMap2525D =
+            new Dictionary<string, string>()
+        {
+                {"identity", "identity"},
+                {"symbolset", "symbolset"},
+                {"symbolentity", "symbolentity"},
+                {"modifier1", "modifier1"},
+                {"modifier2", "modifier2"},
+                {"echelon", "echelon"},
+                {"indicator", "indicator"},
+                {"context", "context"},
+                {"mobility", "mobility"},
+                {"operationalcondition", "operationalcondition"},
+                {"uniquedesignation", "uniquedesignation"},
+                {"higherformation", "higherformation"},
+                {"additionalinformation", "additionalinformation"}
+        };
+
+        private static Dictionary<string, string> fieldMap2525C_B2 =
+            new Dictionary<string, string>()
+        {
+                {"affiliation", "affiliation"},
+                {"extendedfunctioncode", "extendedfunctioncode"},
+                {"echelonmobility", "echelonmobility"},
+                {"status", "status"},
+                {"hqtffd", "hqtffd"},
+                {"uniquedesignation", "uniquedesignation"},
+                {"higherformation", "higherformation"},
+                {"additionalinformation", "additionalinformation"}
+        };
+
+        public static ArcGIS.Core.CIM.CIMDictionaryRenderer CreateDictionaryRenderer()
+        {
+            Dictionary<string, string> fieldMapDictionary;
+
+            if (Standard == SupportedStandardsType.mil2525c_b2)
+                fieldMapDictionary = fieldMap2525C_B2;
+            else
+                fieldMapDictionary = fieldMap2525D;
+
+            ArcGIS.Core.CIM.CIMStringMap[] stringMap = new ArcGIS.Core.CIM.CIMStringMap[fieldMapDictionary.Count()];
+
+            int count = 0;
+            foreach (KeyValuePair<string, string> pair in fieldMapDictionary)
+            {
+                stringMap[count] = new ArcGIS.Core.CIM.CIMStringMap();
+                stringMap[count].Key   = pair.Key;
+                stringMap[count].Value = pair.Value;
+                count++;
+            }
+
+            ArcGIS.Core.CIM.CIMDictionaryRenderer dictionaryRenderer =
+                new ArcGIS.Core.CIM.CIMDictionaryRenderer();
+
+            dictionaryRenderer.DictionaryName = GetDictionaryString();
+            dictionaryRenderer.FieldMap = stringMap;
+
+            return dictionaryRenderer;
         }
 
     }

--- a/source/ProSymbolEditor/ViewModels/MilitarySymbolDockpaneViewModel.cs
+++ b/source/ProSymbolEditor/ViewModels/MilitarySymbolDockpaneViewModel.cs
@@ -1883,7 +1883,7 @@ namespace ProSymbolEditor
         private async void OnMapSelectionChanged(ArcGIS.Desktop.Mapping.Events.MapSelectionChangedEventArgs args)
         {
             // Only allow selection event if addin enabled
-            Task<bool> isEnabledMethod = ProSymbolEditorModule.Current.MilitaryOverlaySchema.IsMapActiveAndAddInEnabledAsync();
+            Task<bool> isEnabledMethod = ProSymbolEditorModule.Current.MilitaryOverlaySchema.ShouldAddInBeEnabledAsync();
             bool enabled = await isEnabledMethod;
 
             if (!enabled)

--- a/source/ProSymbolEditor/ViewModels/MilitarySymbolDockpaneViewModel.cs
+++ b/source/ProSymbolEditor/ViewModels/MilitarySymbolDockpaneViewModel.cs
@@ -1215,8 +1215,7 @@ namespace ProSymbolEditor
                 if (string.IsNullOrEmpty(requiredLayerName))
                     requiredLayerName = "{Layer Not Found}";
 
-                // Warning then return
-                // Could not find layer in ProSymbolEditorModule.Current.MilitaryOverlaySchema.DatabaseName;
+                // Could not find layer in map - ask to re-add it
                 string warningMessage = "The required layer is not in the Active Map. \n" +
                     "Required layer: " + requiredLayerName + ".\n" +
                     "Add this military overlay layer to the map?";
@@ -1231,6 +1230,7 @@ namespace ProSymbolEditor
                     continueWithAdd = await ProSymbolEditorModule.Current.MilitaryOverlaySchema.AddFeatureClassToActiveView(_currentFeatureClassName);
                 }
 
+                // If user cancelled, or unable to add layer provide warning 
                 if (!continueWithAdd)
                 {
                     ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show(


### PR DESCRIPTION
See #242 - removing the military overlay group layer or one of the child layers could lock up the addin and Pro.

Changed to add warnings (and option to cancel) when user removes the military overlay group layer and prompt to add a required layer back to the map if it has been removed but user then tries to add a symbol with the symbol editor.

